### PR TITLE
docs: add complete readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,53 @@
-<div style="text-align: center;">
-  <a href="https://rohan-shridhar.github.io/portfolio/" style="margin: 0 auto; display: inline-block;">Visit Portfolio</a>
-</div>
-<br>
-<h1>📢📢📢📢📢</h1>
+# Rohan S. Mirjankar — Portfolio
 
-# Feel free to contribute a good readme.
-(I suck at documentation 😖)
+Single‑page personal portfolio built with React (UMD) and Babel directly in the browser. Showcases projects, skills, and contact links with a playful, scrollable layout.
 
+**Live site:** https://rohan-shridhar.github.io/portfolio/
 
+## Features
 
+- Responsive single-page layout with anchored navigation
+- About, Skills, Projects (cards), and Contact sections
+- Iconography via Font Awesome CDN
+- Zero-build setup: runs straight from `index.html` with in-browser Babel
 
-### 💫 When to contribute and fix my readme?? <br> 👇 When you know
-- Markdown and/or HTML
-- Git concepts like pull requests, merge, code review, fork etc
+## Quick start
 
-### 💫 How to do it?? <br> 👇 Follow these simple steps
-#### - Fork this repo <br>- Create a branch<br>- Update my Readme.md<br>- Create a pull request and request approval<br>- Mention "closes #3" in the PR
+```bash
+# Clone
+git clone https://github.com/Rohan-Shridhar/portfolio.git
+cd portfolio
+
+# Run a static server (recommended to avoid CORS/file issues)
+npx serve .           # or: python -m http.server 8000
+
+# Then open:
+# http://localhost:3000 (serve) or http://localhost:8000 (python)
+```
+
+You can also open `index.html` directly in your browser, but a local server ensures fonts/icons load correctly.
+
+## Project structure
+
+- `index.html` — loads styles, fonts, React/Babel CDNs, and mounts the app
+- `style.css` — global styles and section theming
+- `*.jsx` — React components loaded via `<script type="text/babel">`
+- `images/` — asset files for hero/skills/project cards
+
+## Development notes
+
+- Uses React 18 UMD builds from CDN; no bundler or build step needed.
+- Update content by editing the JSX component files (e.g., `Home.jsx`, `Skills.jsx`, `Contact.jsx`).
+- Keep sections lightweight to preserve fast load over CDNs.
+
+## Contributing
+
+Improvements are welcome! Please:
+
+1. Fork and branch from `main`.
+2. Make changes (docs or UI tweaks).
+3. Open a PR with a short description; mention related issue numbers if applicable.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- replace placeholder README with a full project overview and live link
- add quick-start instructions for serving locally (npx serve / python http.server)
- document structure, development notes, and contribution guidance

## Rationale
- addresses issue #3 asking for a proper README

## Changes
- README now covers features, setup, structure, contribution steps, and license

## Tests
- not run (docs-only)

Fixes #3